### PR TITLE
Feat/detail service modal

### DIFF
--- a/client/src/components/CardService/CardService.jsx
+++ b/client/src/components/CardService/CardService.jsx
@@ -15,7 +15,9 @@ import { addCart } from "../../redux/actions/index";
 import { useSelector } from "react-redux";
 import { deleteFavs, addFavs } from "../../utils/favs";
 import { getUserInfo } from "../../redux/actions/index";
-
+import Box from "@mui/material/Box";
+import Modal from "@mui/material/Modal";
+import DetailService from "../DetailService/DetailService";
 const IMG_TEMPLATE =
   "https://codyhouse.co/demo/squeezebox-portfolio-template/img/img.png";
 
@@ -26,7 +28,7 @@ function CardService({ service }) {
   const dispatch = useDispatch();
   const [added, setAdded] = useState(false);
   const [favState, setFavState] = useState(false);
-
+  const [open, setOpen] = React.useState(false); //Estado para abrir DetailService modal
   const { title, img, price, id, userId, ratingService } = service;
   const rating = ratingService ? ratingService : 5;
   const fixedTitle = title
@@ -34,6 +36,10 @@ function CardService({ service }) {
       ? `${title.substring(0, 40)}...`
       : title
     : null;
+
+  //Funciones para abrir y cerrar DetailService modal
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
 
   // verificar si ya esta en favorito, prende en rojo
   // el boton de favs de las cards del home o lo deja apagado
@@ -94,7 +100,8 @@ function CardService({ service }) {
   };
   return (
     <Card sx={{ width: 345, height: 420, textDecoration: "none" }}>
-      <CardActionArea component={Link} to={`/services/${id}`}>
+      {/* component={Link} to={`/services/${id}`} */}
+      <CardActionArea onClick={handleOpen}>
         <CardHeader title={fixedTitle} sx={{ pb: "0", height: "64px" }} />
         <Rating
           name="read-only"
@@ -139,6 +146,31 @@ function CardService({ service }) {
           <AddShoppingCartIcon />
         </IconButton>
       </CardActions>
+
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="modal-modal-title"
+        aria-describedby="modal-modal-description"
+      >
+        <Box
+          sx={{
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+            width: "100%",
+            height: "100%",
+            bgcolor: "background.paper",
+            boxShadow: 24,
+            overflowY: "scroll",
+            overflowX: "hidden",
+            m: "60px auto",
+          }}
+        >
+          <DetailService closeModal={handleClose} id={id} />
+        </Box>
+      </Modal>
     </Card>
   );
 }

--- a/client/src/components/CardUser/CardUser.jsx
+++ b/client/src/components/CardUser/CardUser.jsx
@@ -43,7 +43,7 @@ export default function CardUser({ user }) {
         gap={1}
         sx={{ m: "5px 0px" }}
       >
-        <Box gridColumn="span 4">
+        <Box gridColumn="span 5">
           <CardMedia
             component="img"
             image={userImg ? userImg : IMG_TEMPLATE}
@@ -59,10 +59,10 @@ export default function CardUser({ user }) {
           />
         </Box>
 
-        <Box gridColumn="span 8" display="flex" flexDirection="column">
+        <Box gridColumn="span 7" display="flex" flexDirection="column">
           <Box gridColumn="span 12" display="flex" flexDirection="column">
             <Typography
-              variant="h6"
+              variant="subtitle1"
               sx={{
                 height: "minContent",
                 textAlign: "left",

--- a/client/src/components/Comments/Comments.jsx
+++ b/client/src/components/Comments/Comments.jsx
@@ -8,7 +8,12 @@ import SingleComment from "./SingleComment";
 import Rating from "@mui/material/Rating";
 import Typography from "@mui/material/Typography";
 
-export default function Comments({ qualifications, serviceId, updateService }) {
+export default function Comments({
+  qualifications,
+  serviceId,
+  updateService,
+  cookie,
+}) {
   const [loading, setLoading] = useState(false);
   const [comment, setComment] = useState("");
   const [rating, setRating] = useState(0);
@@ -52,44 +57,57 @@ export default function Comments({ qualifications, serviceId, updateService }) {
       maxWidth="100%"
       m="10px auto"
     >
-      <Box gridColumn="span 3" display="flex" flexDirection="row">
-        <Typography variant="subtitle2">Rating: </Typography>
-        <Rating
-          name="rating"
-          value={rating}
-          precision={1}
-          onChange={(event, newValue) => {
-            setRating((rating) => newValue);
-          }}
-        />
+      {cookie && (
+        <>
+          <Box gridColumn="span 12" display="flex" flexDirection="row">
+            <Typography
+              variant="subtitle1"
+              sx={{ alignSelf: "center", mr: "5px" }}
+            >
+              Rating:
+            </Typography>
+            <Rating
+              name="rating"
+              value={rating}
+              precision={1}
+              size="large"
+              onChange={(event, newValue) => {
+                setRating((rating) => newValue);
+              }}
+            />
 
-        <Typography variant="h5" sx={{ pl: "10px" }}>
-          {rating}
-        </Typography>
-      </Box>
+            <Typography
+              variant="h5"
+              sx={{ pl: "10px", verticalAlign: "middle" }}
+            >
+              {`${rating} stars`}
+            </Typography>
+          </Box>
 
-      <Box gridColumn="span 10">
-        <TextareaAutosize
-          minRows={4}
-          maxRows={8}
-          aria-label="comment area"
-          placeholder="Leave your comment here..."
-          style={{ width: "100%" }}
-          value={comment}
-          onChange={(event) => handleChange(event)}
-        />
-      </Box>
-      <Box gridColumn="span 2">
-        <Button
-          onClick={() => handleClick(comment, rating, serviceId)}
-          variant="contained"
-          endIcon={<SendIcon />}
-          disabled={loading}
-        >
-          {loading ? "Wait" : "Send"}
-        </Button>
-      </Box>
+          <Box gridColumn="span 10">
+            <TextareaAutosize
+              minRows={4}
+              maxRows={8}
+              aria-label="comment area"
+              placeholder="Leave your comment here..."
+              style={{ width: "100%" }}
+              value={comment}
+              onChange={(event) => handleChange(event)}
+            />
+          </Box>
 
+          <Box gridColumn="span 2">
+            <Button
+              onClick={() => handleClick(comment, rating, serviceId)}
+              variant="contained"
+              endIcon={<SendIcon />}
+              disabled={loading}
+            >
+              {loading ? "Wait" : "Send"}
+            </Button>
+          </Box>
+        </>
+      )}
       <Box gridColumn="span 12">
         {qualifications &&
           qualifications.map((q) => {

--- a/client/src/components/DetailService/DetailService.jsx
+++ b/client/src/components/DetailService/DetailService.jsx
@@ -138,6 +138,7 @@ export default function DetailService({ id }) {
             updateService={updateService}
             serviceId={id}
             qualifications={qualifications}
+            cookie={cookie}
           />
         </Box>
 
@@ -183,6 +184,13 @@ export default function DetailService({ id }) {
               {" "}
               {title}{" "}
             </Typography>
+          </Box>
+          <Box
+            gridColumn="span 12"
+            display="flex"
+            flexDirection="row"
+            justifyContent="left"
+          >
             <Rating
               name="read-only"
               value={Number(rating)}
@@ -190,9 +198,13 @@ export default function DetailService({ id }) {
               readOnly
               sx={{}}
             />
-            {qualifications
-              ? `${qualifications.length} opiniones`
-              : "0 opiniones"}
+            <Typography variant="subtitle 1" sx={{ ml: "10px" }}>
+              {qualifications
+                ? qualifications.length === 1
+                  ? ` ${qualifications.length} opinion`
+                  : ` ${qualifications.length} opinions`
+                : "0 opiniones"}
+            </Typography>
           </Box>
 
           <Box

--- a/client/src/components/DetailService/DetailService.jsx
+++ b/client/src/components/DetailService/DetailService.jsx
@@ -18,7 +18,7 @@ import { AddShoppingCart, Favorite, Share, Close } from "@mui/icons-material";
 import CardUser from "../CardUser/CardUser";
 import Comments from "../Comments/Comments";
 
-export default function DetailService({ id }) {
+export default function DetailService({ id, closeModal }) {
   let [service, setService] = useState({ service: {}, user: {} });
   const [favState, setFavState] = useState(false);
   const [added, setAdded] = useState(false);
@@ -115,7 +115,7 @@ export default function DetailService({ id }) {
 
   return (
     <>
-      <Nav />
+      {/* <Nav /> */}
       <Box
         display="grid"
         gridTemplateColumns="repeat(12, 1fr)"
@@ -123,7 +123,7 @@ export default function DetailService({ id }) {
         p={2}
         border="solid 1px lightgrey"
         maxWidth="80%"
-        m="60px auto"
+        m="0px auto"
       >
         <Box gridColumn="span 8" p={2}>
           <CardMedia
@@ -167,7 +167,8 @@ export default function DetailService({ id }) {
             </Box>
 
             <Box gridColumn="span 6">
-              <IconButton onClick={() => handleClose()}>
+              {/* () => handleClose() */}
+              <IconButton onClick={closeModal}>
                 <Close />
               </IconButton>
             </Box>


### PR DESCRIPTION
Se agrego a DetailService en el componente CardService como Modal

Cuando se renderizaba el detail se desmontaba el home y cuando se cerraba habia que cargar nuevamente los servicios.
Ahora, como se muestra modal, el home nunca se desmonta y ganamos tiempo.
La apariencia y funcionalidad quedo igual a como estaba antes